### PR TITLE
Added general settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,13 @@ if (process.env.DEV) {
 
 app.use(cors())
 
+const { getSettingsRouter, setDefaultSettings } = require('./routers/generalSettingsRouter')
 const tournamentDataRouter = require('./routers/tournamentDataRouter')
 const matchTeamRouter = require('./routers/matchTeamRouter')
 
+setDefaultSettings()
+
+app.use('/settings', getSettingsRouter())
 app.use('/tournamentData', tournamentDataRouter)
 
 const teamLogic = require('./logic/teamLogic')

--- a/routers/generalSettingsRouter.js
+++ b/routers/generalSettingsRouter.js
@@ -10,14 +10,14 @@ const MONGU_URI = process.env.MONGO
 const SETTING_COLLECTION_NAME = 'settings'
 
 exports.setDefaultSettings = function () {
-  const settings = {
+  const defaultSettings = {
     'tournamentLevel': 'practice',
     'tournamentTitle': 'World Festival 2018'
   }
   MongoClient.connect(MONGU_URI).then(connection => {
     connection.db().collection(SETTING_COLLECTION_NAME).findOne().then(response => {
       if (!response) {
-        return connection.db().collection(SETTING_COLLECTION_NAME).insert(settings)
+        return connection.db().collection(SETTING_COLLECTION_NAME).insert(defaultSettings)
       }
     })
   })

--- a/routers/generalSettingsRouter.js
+++ b/routers/generalSettingsRouter.js
@@ -1,0 +1,62 @@
+'use strict'
+const express = require('express')
+const MongoClient = require('mongodb').MongoClient
+const MsLogger = require('@first-lego-league/ms-logger').Logger()
+const { authroizationMiddlware } = require('@first-lego-league/ms-auth')
+
+const adminAction = authroizationMiddlware(['admin', 'development'])
+
+const MONGU_URI = process.env.MONGO
+const SETTING_COLLECTION_NAME = 'settings'
+
+exports.setDefaultSettings = function () {
+  const settings = {
+    'tournamentLevel': 'practice',
+    'tournamentTitle': 'World Festival 2018'
+  }
+  MongoClient.connect(MONGU_URI).then(connection => {
+    connection.db().collection(SETTING_COLLECTION_NAME).findOne().then(response => {
+      if (!response) {
+        return connection.db().collection(SETTING_COLLECTION_NAME).insert(settings)
+      }
+    })
+  })
+}
+
+exports.getSettingsRouter = function () {
+  const router = express.Router()
+
+  router.get('/:setting', (req, res) => {
+    MongoClient.connect(MONGU_URI).then(connection => {
+      connection.db().collection(SETTING_COLLECTION_NAME).findOne().then(data => {
+        if (!data) {
+          res.sendStatus(404)
+          return
+        }
+
+        res.send(data[req.params.setting])
+      })
+    }).catch(err => {
+      MsLogger.error(err)
+      res.sendStatus(500)
+    })
+  })
+
+  router.put('/:setting', adminAction, (req, res) => {
+    MongoClient.connect(MONGU_URI).then(connection => {
+      const setDocument = {}
+      setDocument[req.params.setting] = req.body[req.params.setting]
+      connection.db().collection(SETTING_COLLECTION_NAME).findOneAndUpdate({}, { $set: setDocument })
+        .then(dbResponse => {
+          if (dbResponse.ok === 1) {
+            res.sendStatus(204)
+          }
+        })
+    }).catch(err => {
+      MsLogger.error(err)
+      res.sendStatus(500)
+    })
+  })
+
+  return router
+}


### PR DESCRIPTION
Added a general settings router and a collection in mongo.
Its going as follows
- get: /settings/:settingName
- put (for update): /settings/:settingName
   And the body: `{"settingName": "settingData"}`

For example, to get the tournament title:
/settings/tournamentTitle

And, A problem:
Where does the perlimenery data is coming from?
the perlimenery is used to create the document for the first time, and to reset it, if we want this feature 